### PR TITLE
Allow parsing productNumber as string when creating ProductLine with ::new function

### DIFF
--- a/src/Abstracts/Endpoint.php
+++ b/src/Abstracts/Endpoint.php
@@ -4,9 +4,7 @@ namespace Morningtrain\Economic\Abstracts;
 
 abstract class Endpoint
 {
-    public function __construct(protected string $endpoint, protected ?array $references = null)
-    {
-    }
+    public function __construct(protected string $endpoint, protected ?array $references = null) {}
 
     public function getEndpoint(...$references): string
     {

--- a/src/Abstracts/Resource.php
+++ b/src/Abstracts/Resource.php
@@ -75,7 +75,7 @@ abstract class Resource implements JsonSerializable
             if (! empty($attribute[0]) && ! empty($value) && is_array($value)) {
                 $resourceType = $attribute[0]->newInstance();
 
-                $collection = new Collection();
+                $collection = new Collection;
 
                 foreach ($value as $item) {
                     $collection->add(new ($resourceType->getTypeClass())($item));

--- a/src/Attributes/Resources/Create.php
+++ b/src/Attributes/Resources/Create.php
@@ -7,7 +7,5 @@ use Morningtrain\Economic\Abstracts\Endpoint;
 
 #[Attribute(Attribute::TARGET_CLASS)] class Create extends Endpoint
 {
-    public function __construct(protected string $endpoint)
-    {
-    }
+    public function __construct(protected string $endpoint) {}
 }

--- a/src/Attributes/Resources/Delete.php
+++ b/src/Attributes/Resources/Delete.php
@@ -5,6 +5,4 @@ namespace Morningtrain\Economic\Attributes\Resources;
 use Attribute;
 use Morningtrain\Economic\Abstracts\Endpoint;
 
-#[Attribute(Attribute::TARGET_CLASS)] class Delete extends Endpoint
-{
-}
+#[Attribute(Attribute::TARGET_CLASS)] class Delete extends Endpoint {}

--- a/src/Attributes/Resources/GetCollection.php
+++ b/src/Attributes/Resources/GetCollection.php
@@ -7,7 +7,5 @@ use Morningtrain\Economic\Abstracts\Endpoint;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)] class GetCollection extends Endpoint
 {
-    public function __construct(protected string $endpoint)
-    {
-    }
+    public function __construct(protected string $endpoint) {}
 }

--- a/src/Attributes/Resources/GetSingle.php
+++ b/src/Attributes/Resources/GetSingle.php
@@ -7,7 +7,5 @@ use Morningtrain\Economic\Abstracts\Endpoint;
 
 #[Attribute(Attribute::TARGET_CLASS)] class GetSingle extends Endpoint
 {
-    public function __construct(protected string $endpoint)
-    {
-    }
+    public function __construct(protected string $endpoint) {}
 }

--- a/src/Attributes/Resources/Properties/ApiFormatting/ResourceToPrimaryKey.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/ResourceToPrimaryKey.php
@@ -8,9 +8,7 @@ use Morningtrain\Economic\Interfaces\ApiFormatter;
 
 #[Attribute(Attribute::TARGET_PROPERTY)] class ResourceToPrimaryKey implements ApiFormatter
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function format($value): mixed
     {

--- a/src/Attributes/Resources/Properties/Filterable.php
+++ b/src/Attributes/Resources/Properties/Filterable.php
@@ -4,6 +4,4 @@ namespace Morningtrain\Economic\Attributes\Resources\Properties;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)] class Filterable
-{
-}
+#[Attribute(Attribute::TARGET_PROPERTY)] class Filterable {}

--- a/src/Attributes/Resources/Properties/PrimaryKey.php
+++ b/src/Attributes/Resources/Properties/PrimaryKey.php
@@ -4,6 +4,4 @@ namespace Morningtrain\Economic\Attributes\Resources\Properties;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)] class PrimaryKey
-{
-}
+#[Attribute(Attribute::TARGET_PROPERTY)] class PrimaryKey {}

--- a/src/Attributes/Resources/Properties/Required.php
+++ b/src/Attributes/Resources/Properties/Required.php
@@ -4,6 +4,4 @@ namespace Morningtrain\Economic\Attributes\Resources\Properties;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)] class Required
-{
-}
+#[Attribute(Attribute::TARGET_PROPERTY)] class Required {}

--- a/src/Attributes/Resources/Properties/ResourceType.php
+++ b/src/Attributes/Resources/Properties/ResourceType.php
@@ -7,9 +7,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class ResourceType
 {
-    public function __construct(public string $typeClass)
-    {
-    }
+    public function __construct(public string $typeClass) {}
 
     public function getTypeClass(): string
     {

--- a/src/Attributes/Resources/Properties/Sortable.php
+++ b/src/Attributes/Resources/Properties/Sortable.php
@@ -4,6 +4,4 @@ namespace Morningtrain\Economic\Attributes\Resources\Properties;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)] class Sortable
-{
-}
+#[Attribute(Attribute::TARGET_PROPERTY)] class Sortable {}

--- a/src/Attributes/Resources/Update.php
+++ b/src/Attributes/Resources/Update.php
@@ -5,6 +5,4 @@ namespace Morningtrain\Economic\Attributes\Resources;
 use Attribute;
 use Morningtrain\Economic\Abstracts\Endpoint;
 
-#[Attribute(Attribute::TARGET_CLASS)] class Update extends Endpoint
-{
-}
+#[Attribute(Attribute::TARGET_CLASS)] class Update extends Endpoint {}

--- a/src/Classes/EconomicCollectionIterator.php
+++ b/src/Classes/EconomicCollectionIterator.php
@@ -18,9 +18,7 @@ class EconomicCollectionIterator implements ArrayAccess, Countable, SeekableIter
 
     protected int $currentPosition = 0;
 
-    public function __construct(protected string $self, protected string $resourceClass)
-    {
-    }
+    public function __construct(protected string $self, protected string $resourceClass) {}
 
     protected function getItem(int $position): ?Resource
     {

--- a/src/Classes/EconomicQueryBuilder.php
+++ b/src/Classes/EconomicQueryBuilder.php
@@ -18,9 +18,7 @@ class EconomicQueryBuilder
 
     protected string|Endpoint $endpoint;
 
-    public function __construct(protected string $resourceClass)
-    {
-    }
+    public function __construct(protected string $resourceClass) {}
 
     public function setEndpoint(string|Endpoint $endpoint): static
     {

--- a/src/Classes/EconomicQueryFilterBuilder.php
+++ b/src/Classes/EconomicQueryFilterBuilder.php
@@ -42,9 +42,7 @@ class EconomicQueryFilterBuilder
 
     protected array $filters = [];
 
-    public function __construct(protected string $relation)
-    {
-    }
+    public function __construct(protected string $relation) {}
 
     protected function convertOperator(string $operator): string
     {

--- a/src/Classes/EconomicRelatedResource.php
+++ b/src/Classes/EconomicRelatedResource.php
@@ -12,9 +12,7 @@ use Morningtrain\Economic\Services\EconomicApiService;
  */
 class EconomicRelatedResource
 {
-    public function __construct(protected Endpoint $endpointCollection, protected Endpoint $endpointSingle, protected string $resourceClass, protected array $references)
-    {
-    }
+    public function __construct(protected Endpoint $endpointCollection, protected Endpoint $endpointSingle, protected string $resourceClass, protected array $references) {}
 
     /**
      * @return R|null

--- a/src/DTOs/Invoice/ProductLine.php
+++ b/src/DTOs/Invoice/ProductLine.php
@@ -37,7 +37,7 @@ class ProductLine extends Resource
     public ?float $unitNetPrice;
 
     public static function new(
-        Product|int $product,
+        Product|int|string $product,
         float $quantity,
         float $unitNetPrice,
         ?string $description = null,

--- a/src/Resources/AccountingYear/Voucher.php
+++ b/src/Resources/AccountingYear/Voucher.php
@@ -4,6 +4,4 @@ namespace Morningtrain\Economic\Resources\AccountingYear;
 
 use Morningtrain\Economic\Abstracts\Resource;
 
-class Voucher extends Resource
-{
-}
+class Voucher extends Resource {}

--- a/src/Resources/Customer/Total.php
+++ b/src/Resources/Customer/Total.php
@@ -4,6 +4,4 @@ namespace Morningtrain\Economic\Resources\Customer;
 
 use Morningtrain\Economic\Abstracts\Resource;
 
-class Total extends Resource
-{
-}
+class Total extends Resource {}

--- a/src/Resources/Department.php
+++ b/src/Resources/Department.php
@@ -6,6 +6,4 @@ use Morningtrain\Economic\Abstracts\Resource;
 use Morningtrain\Economic\Attributes\Resources\GetCollection;
 
 #[GetCollection()]
-class Department extends Resource
-{
-}
+class Department extends Resource {}

--- a/src/Traits/Resources/HasLines.php
+++ b/src/Traits/Resources/HasLines.php
@@ -17,7 +17,7 @@ trait HasLines
     public function addLine(ProductLine $line): static
     {
         if (is_null($this->lines)) {
-            $this->lines = new Collection();
+            $this->lines = new Collection;
         }
 
         $this->lines->add($line);

--- a/tests/Unit/ProductLineTest.php
+++ b/tests/Unit/ProductLineTest.php
@@ -1,11 +1,7 @@
 <?php
 
-use Morningtrain\Economic\Classes\EconomicCollection;
-use Morningtrain\Economic\Classes\EconomicResponse;
 use Morningtrain\Economic\DTOs\Invoice\ProductLine;
 use Morningtrain\Economic\Resources\Product;
-use Morningtrain\Economic\Resources\ProductGroup;
-use Morningtrain\Economic\Resources\Unit;
 
 it('allows setting product from string', function () {
     $productLine = ProductLine::new(

--- a/tests/Unit/ProductLineTest.php
+++ b/tests/Unit/ProductLineTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Morningtrain\Economic\Classes\EconomicCollection;
+use Morningtrain\Economic\Classes\EconomicResponse;
+use Morningtrain\Economic\DTOs\Invoice\ProductLine;
+use Morningtrain\Economic\Resources\Product;
+use Morningtrain\Economic\Resources\ProductGroup;
+use Morningtrain\Economic\Resources\Unit;
+
+it('allows setting product from string', function () {
+    $productLine = ProductLine::new(
+        product: 'test',
+        quantity: 1,
+        unitNetPrice: 100,
+    );
+
+    expect($productLine->product)
+        ->toBeInstanceOf(Product::class)
+        ->productNumber->toBe('test');
+});


### PR DESCRIPTION
Currently we only allow parsing a Product or int. Since the $productNumber on the Product resource is a string, we should also be able to parse strings here.