### PR TITLE
Hotfix/discounts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "psr/log": "^3.0.2"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
@@ -6,7 +6,8 @@ use Attribute;
 use Morningtrain\Economic\Interfaces\ApiFormatter;
 
 #[Attribute(Attribute::TARGET_PROPERTY)] class FloatPrecision implements ApiFormatter
-{
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class FloatPrecision implements ApiFormatter
     public function __construct(
         protected int $precision
     ) {}

--- a/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
@@ -11,7 +11,7 @@ use Morningtrain\Economic\Interfaces\ApiFormatter;
         protected int $precision
     ) {}
 
-    public function format($value): float
+    public function format($value): mixed
     {
         if (! is_numeric($value)) {
             return $value;

--- a/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
@@ -5,9 +5,9 @@ namespace Morningtrain\Economic\Attributes\Resources\Properties\ApiFormatting;
 use Attribute;
 use Morningtrain\Economic\Interfaces\ApiFormatter;
 
-#[Attribute(Attribute::TARGET_PROPERTY)] class FloatPrecision implements ApiFormatter
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class FloatPrecision implements ApiFormatter
+{
     public function __construct(
         protected int $precision
     ) {}

--- a/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Morningtrain\Economic\Attributes\Resources\Properties\ApiFormatting;
+
+use Attribute;
+use Morningtrain\Economic\Interfaces\ApiFormatter;
+
+#[Attribute(Attribute::TARGET_PROPERTY)] class FloatPrecision implements ApiFormatter
+{
+    public function __construct(
+        protected int $precision
+    ) {
+    }
+
+    public function format($value): float
+    {
+        if(!is_numeric($value)) {
+            return $value;
+        }
+
+        return round((float) $value, $this->precision);
+    }
+}

--- a/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php
@@ -9,12 +9,11 @@ use Morningtrain\Economic\Interfaces\ApiFormatter;
 {
     public function __construct(
         protected int $precision
-    ) {
-    }
+    ) {}
 
     public function format($value): float
     {
-        if(!is_numeric($value)) {
+        if (! is_numeric($value)) {
             return $value;
         }
 

--- a/src/Attributes/Resources/Properties/ApiFormatting/ResourceToPrimaryKey.php
+++ b/src/Attributes/Resources/Properties/ApiFormatting/ResourceToPrimaryKey.php
@@ -13,7 +13,7 @@ use Morningtrain\Economic\Interfaces\ApiFormatter;
     public function format($value): mixed
     {
         if (! is_a($value, Resource::class)) {
-            throw new \InvalidArgumentException('ResourceToArray can only be used on properties of type Resource');
+            throw new \InvalidArgumentException('ResourceToPrimaryKey can only be used on properties of type Resource');
         }
 
         return $value->getPrimaryKey();

--- a/src/DTOs/Invoice/ProductLine.php
+++ b/src/DTOs/Invoice/ProductLine.php
@@ -3,6 +3,7 @@
 namespace Morningtrain\Economic\DTOs\Invoice;
 
 use Morningtrain\Economic\Abstracts\Resource;
+use Morningtrain\Economic\Attributes\Resources\Properties\ApiFormatting\FloatPrecision;
 use Morningtrain\Economic\Attributes\Resources\Properties\ApiFormatting\ResourceToArray;
 use Morningtrain\Economic\Resources\DepartmentalDistribution;
 use Morningtrain\Economic\Resources\Product;
@@ -16,6 +17,7 @@ class ProductLine extends Resource
 
     public ?string $description;
 
+    #[FloatPrecision(2)]
     public ?float $discountPercentage;
 
     public ?float $marginInBaseCurrency;


### PR DESCRIPTION
This pull request introduces a new attribute for formatting float precision in API resources, applies it to the `discountPercentage` property in `ProductLine`, and makes a minor fix to an exception message. Additionally, it updates dependencies in `composer.json`. The most important changes are:

### New Feature: Float Precision Attribute

* Added the `FloatPrecision` attribute in `src/Attributes/Resources/Properties/ApiFormatting/FloatPrecision.php`, allowing properties to be automatically rounded to a specified precision when formatted for the API.

### Usage of Float Precision

* Applied the `#[FloatPrecision(2)]` attribute to the `discountPercentage` property in the `ProductLine` DTO, ensuring this value is rounded to two decimal places. [[1]](diffhunk://#diff-d29f97b0baeef7a960c9442628e3e4c03202c2eb207026aedcc1ed9d8260130aR20) [[2]](diffhunk://#diff-d29f97b0baeef7a960c9442628e3e4c03202c2eb207026aedcc1ed9d8260130aR6)

### Bug Fix

* Corrected the exception message in `ResourceToPrimaryKey` to reference the correct class name.

### Dependency Updates

* Added `psr/log` as a required dependency in `composer.json` to ensure compatibility with logging interfaces.